### PR TITLE
Remove padding for image grid

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -398,6 +398,7 @@ footer {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 10px;
+  padding: 0;
 }
 
 .image-grid li {


### PR DESCRIPTION
The images in the screenshots page are in a list element that has padding to the left, pushing the images off-center. Especially noticeable on mobile. This PR removes the padding so the images are centered.